### PR TITLE
add version requirement for python-telegram-bot, fixes #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot
+python-telegram-bot==13.15
 VaderSentiment
 openai
 regex


### PR DESCRIPTION
This PR adds a version requirement on the `python-telegram-bot` package, as the code is not working with the latest version of that package.

Fixes #1 